### PR TITLE
fix: removed unused libraries that does not work with python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,10 +36,10 @@ six==1.16.0
 sympy==1.13.2
 tifffile==2023.7.10
 tomli==2.0.1
-torch==2.4.1
-torchaudio==2.4.1
-torchvision==0.19.1
+#torch==2.2.2
+#torchaudio==2.2.2
+#torchvision==0.17.2
 tqdm==4.66.5
-triton==3.0.0
+#triton==3.0.0
 typing_extensions==4.12.2
 zipp==3.20.1

--- a/test/environment_test.py
+++ b/test/environment_test.py
@@ -1,14 +1,14 @@
-import torch
-import platform
-import warnings
-import pytest
+#import torch
+#import platform
+#import warnings
+#import pytest
 
-@pytest.mark.environment
-def test_cuda():
-    if not torch.cuda.is_available():
-        warnings.warn("You do not have CUDA enabled on your machine, large tensor operations will be slow")
+#@pytest.mark.environment
+#def test_cuda():
+    #if not torch.cuda.is_available():
+        #warnings.warn("You do not have CUDA enabled on your machine, large tensor operations will be slow")
 
-@pytest.mark.environment
-def test_os():
-    if platform.system() == "Windows":
-        warnings.warn("You might encounter issues with gym-super-mario-bros on Windows")
+#@pytest.mark.environment
+#def test_os():
+    #if platform.system() == "Windows":
+        #warnings.warn("You might encounter issues with gym-super-mario-bros on Windows")


### PR DESCRIPTION
We don't use pytorch.... And PyTorch version 2.4.1 does not work with Python 3.8....